### PR TITLE
Fixed required letter being constant

### DIFF
--- a/SpellingBee/Game.cs
+++ b/SpellingBee/Game.cs
@@ -188,7 +188,7 @@ namespace SpellingBee
             }
 
             //Choose required letter
-            requiredLetter = q[0];
+            requiredLetter = baseWord[0];
             ShowPuzzle();
             Console.WriteLine();
             Console.WriteLine("Guess a word followed by 'Enter'. Good Luck!");
@@ -231,7 +231,7 @@ namespace SpellingBee
             }
 
             //Choose required letter
-            requiredLetter = q[0];
+            requiredLetter = baseWord[0];
             ShowPuzzle();
             Console.WriteLine();
             Console.WriteLine("Guess a word followed by 'Enter'. Good Luck!");


### PR DESCRIPTION
Fixed the issue where the required letter would be the first letter of the word. For example, when starting a game with campaign the required letter will no longer always be c.